### PR TITLE
Flexmojos 4.x

### DIFF
--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/report/CoverageReportMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/report/CoverageReportMojo.java
@@ -20,11 +20,14 @@ package net.flexmojos.oss.plugin.report;
 import static net.flexmojos.oss.util.PathUtil.files;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.codehaus.plexus.util.FileUtils;
+
 import net.flexmojos.oss.plugin.AbstractMavenMojo;
 import net.flexmojos.oss.plugin.SourcePathAware;
 
@@ -79,6 +82,19 @@ public class CoverageReportMojo
         throws MojoExecutionException, MojoFailureException
     {
         // nothing to be done, the lifecycle deal with this report generation
+    	
+    	File index = new File(coverageReportOutputDirectory.getAbsolutePath() + "/index.bak.html");
+    	if(index.exists())
+    	{
+        	// Fix at site phase
+        	// Copy index.bak.html to index.html
+        	// In the site phase, index.html is opened with a writer by the site plugin and erase its content. index.bak.html is a backup and replaces index.html.
+    		try {
+    			FileUtils.copyFile(index, new File(coverageReportOutputDirectory.getAbsolutePath() + "/index.html"));
+			} catch (IOException e) {
+				getLog().error(e.getMessage());
+			}
+    	}
     }
 
     public String getDescription( Locale locale )

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/test/TestRunMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/test/TestRunMojo.java
@@ -30,7 +30,9 @@ import java.util.List;
 import org.apache.maven.plugin.Mojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
+import org.apache.velocity.texen.util.FileUtil;
 import org.codehaus.plexus.util.DirectoryScanner;
+import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
@@ -319,8 +321,15 @@ public class TestRunMojo
                 try
                 {
                     reporter.generateReport( request );
+                    File index = new File(coverageOutputDirectory.getAbsolutePath() + "/index.html");
+                    if(index.exists())
+                    	FileUtils.copyFile(index, new File(coverageOutputDirectory.getAbsolutePath() + "/index.bak.html"));
                 }
                 catch ( CoverageReportException e )
+                {
+                    throw new MojoExecutionException( e.getMessage(), e );
+                }
+                catch ( IOException e )
                 {
                     throw new MojoExecutionException( e.getMessage(), e );
                 }

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/war/CopyMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/war/CopyMojo.java
@@ -32,6 +32,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.model.Profile;
 import org.apache.maven.project.ProjectBuilder;
 import org.apache.maven.project.ProjectBuildingException;
 import org.apache.maven.project.ProjectBuildingRequest;
@@ -234,6 +235,11 @@ public class CopyMojo
             request.setLocalRepository( localRepository );
             request.setRemoteRepositories( remoteRepositories );
             request.setResolveDependencies( true );
+            ArrayList<String> ids = new ArrayList<String>();
+            for(Profile profile : project.getActiveProfiles()){
+            	ids.add(profile.getId());
+            }
+            request.setActiveProfileIds(ids);
             request.setRepositorySession( session.getRepositorySession() );
             return projectBuilder.build( artifact, request ).getProject();
         }


### PR DESCRIPTION
I updated the pull request as you said.

Forwarded request :

I added a fix and a feature that can be interesting :
1. _Fix:_
   When using copy-flex-resources on a war project, the project builder used to get rsls' maven project does not take care of the activated profiles. Now, the war activated profiles are used to process these dependencies, allowing to set the scope of rsls with profiles' properties.
2. _Feature:_
   Added a basic flashbuilder configuration generator.
   It uses the velocity engine and et slightly modified version of file templates in resources/templates/flexbuilder.
   Basicly, it adds swc dependencies to the build path for autocomplete purpose. Moreover, if the artifact is available with a classifier 'sources', the sources will be fetched, unzipped in the local maven repository and linked in the flashbuilder configuration.
   Thus developer will can look into the dependency code for debugging purposes.

EDIT:
1. _Fix:_
   When compiling test classes, it uses flexmojos.properties to get the version. It gets ths String "${project.version}" and is not resolved. Thus, maven require <code>net.flexmojos.oss:flexmojos-unittest-support:flex:swc:${project.version}</code> as a dependency.

I set the property to 5.1-beta-SNAPSHOT to have the correct dependency.

EDIT2 :
1. _Fix:_
   Coverage report is empty on phase 'site'.

The maven-site-plugin creates a writer on converage/index.html before the executeReport(Sink, Local) is executed. 
Or the coverage/index.html is generated during test-swf goal before that call.
So the newly created writer erases the generated coverage/index.html.
I copied the index.html to index.bak.html right after the report is generated and then copied back to index.html on Coverage Report Mojo execution.
