### PR TITLE
Broken build and incremental compitation fixes.

### DIFF
--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/artifacthandler/AneArtifactHandler.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/artifacthandler/AneArtifactHandler.java
@@ -15,11 +15,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-package org.sonatype.flexmojos.plugin.artifacthandler;
+package net.flexmojos.oss.plugin.artifacthandler;
 
+import net.flexmojos.oss.plugin.common.FlexExtension;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.codehaus.plexus.component.annotations.Component;
-import org.sonatype.flexmojos.plugin.common.FlexExtension;
 
 @Component( role = ArtifactHandler.class, hint = FlexExtension.ANE )
 public class AneArtifactHandler

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/compiler/AbstractFlexCompilerMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/compiler/AbstractFlexCompilerMojo.java
@@ -1955,7 +1955,8 @@ public abstract class AbstractFlexCompilerMojo<CFG, C extends AbstractFlexCompil
             return this.metadata.getDate();
         }
 
-        return DATE_FORMAT.format( new Date() );
+        // If incremental compilation is enabled then we don't use current time
+        return incremental ? "0:00" : DATE_FORMAT.format( new Date() );
     }
 
     public Boolean getDebug()

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/compiler/AbstractFlexCompilerMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/compiler/AbstractFlexCompilerMojo.java
@@ -38,6 +38,7 @@ import static net.flexmojos.oss.plugin.common.FlexExtension.SWC;
 import static net.flexmojos.oss.plugin.common.FlexExtension.SWF;
 import static net.flexmojos.oss.plugin.common.FlexExtension.SWZ;
 import static net.flexmojos.oss.plugin.common.FlexExtension.XML;
+import static net.flexmojos.oss.plugin.common.FlexExtension.ANE;
 import static net.flexmojos.oss.plugin.common.FlexScopes.CACHING;
 import static net.flexmojos.oss.plugin.common.FlexScopes.COMPILE;
 import static net.flexmojos.oss.plugin.common.FlexScopes.EXTERNAL;

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/compiler/attributes/MavenFontsConfiguration.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/compiler/attributes/MavenFontsConfiguration.java
@@ -214,7 +214,8 @@ public class MavenFontsConfiguration
         File fontsSer = new File( outputDirectory, "fonts.ser" );
         try
         {
-            FileUtils.copyURLToFile( url, fontsSer );
+            if (!fontsSer.exists())
+                FileUtils.copyURLToFile( url, fontsSer );
         }
         catch ( IOException e )
         {

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/test/TestCompilerMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/test/TestCompilerMojo.java
@@ -28,6 +28,7 @@ import static net.flexmojos.oss.matcher.artifact.ArtifactMatcher.scope;
 import static net.flexmojos.oss.matcher.artifact.ArtifactMatcher.type;
 import static net.flexmojos.oss.matcher.artifact.ArtifactMatcher.version;
 import static net.flexmojos.oss.plugin.common.FlexExtension.SWC;
+import static net.flexmojos.oss.plugin.common.FlexExtension.ANE;
 import static net.flexmojos.oss.plugin.common.FlexExtension.XML;
 import static net.flexmojos.oss.plugin.common.FlexScopes.CACHING;
 import static net.flexmojos.oss.plugin.common.FlexScopes.COMPILE;

--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/utilities/MavenUtils.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/utilities/MavenUtils.java
@@ -142,7 +142,8 @@ public class MavenUtils
         File fontsSer = new File( build.getOutputDirectory(), "fonts.ser" );
         try
         {
-            FileUtils.copyURLToFile( url, fontsSer );
+            if (!fontsSer.exists())
+                FileUtils.copyURLToFile( url, fontsSer );
         }
         catch ( IOException e )
         {


### PR DESCRIPTION
1) I fix build problem that appeared in my previous pull request. Sorry.
2) fix this bug https://issues.sonatype.org/browse/FLEXMOJOS-201

Why isn't worked? Two reasons:
- FlexMojos rewrites target/classes/fonts.ser every compilation. In this flex compiler invalidate cache.
- metadata.date always new. This also leads to the cache invalidation.
