### PR TITLE
add AIR 3.1 support for Flex 4.6

### DIFF
--- a/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/AbstractMavenMojo.java
+++ b/flexmojos-maven-plugin/src/main/java/net/flexmojos/oss/plugin/AbstractMavenMojo.java
@@ -420,6 +420,10 @@ public abstract class AbstractMavenMojo
         if (airVersion == null)
         {
             int[] version = VersionUtils.splitVersion( getCompilerVersion() );
+            if ( VersionUtils.isMinVersionOK( version, new int[] { 4, 6 } ) )
+            {
+                return "3.1";
+            }
             if ( VersionUtils.isMinVersionOK( version, new int[] { 4, 5, 0, 19787 } ) )
             {
                 return "2.6";


### PR DESCRIPTION
Here is a patch to support Air 3.1, in particular for unit tests, since Flex SDK 4.6
