### PR TITLE
Fix FlexUnit4 partial report when dataprovider are used

### DIFF
--- a/flexmojos-testing/flexmojos-unittest-flexunit4/src/main/flex/org/sonatype/flexmojos/unitestingsupport/flexunit4/FlexUnit4Listener.as
+++ b/flexmojos-testing/flexmojos-unittest-flexunit4/src/main/flex/org/sonatype/flexmojos/unitestingsupport/flexunit4/FlexUnit4Listener.as
@@ -35,6 +35,7 @@ package org.sonatype.flexmojos.unitestingsupport.flexunit4
 
 	public class FlexUnit4Listener implements IRunListener, UnitTestRunner
 	{
+		private static const NB_TEST:int = 42;
 		private var running:Boolean = false;
 
 		private var _socketReporter:SocketReporter;
@@ -58,12 +59,14 @@ package org.sonatype.flexmojos.unitestingsupport.flexunit4
 			//This run statements executes the unit tests for the FlexUnit4 framework
  			var result:Result = flexUnitCore.run.apply( flexUnitCore, tests ); // The result seems to be always null
 
-			var count:int = 0;
-			for each (var test:Class in tests)
-			{
-				count += countTestCases(test);
-			}
-			return count;
+			//var count:int = 0;
+			//for each (var test:Class in tests)
+			//{
+			//	count += countTestCases(test);
+			//}
+			//return count;
+
+			return NB_TEST;
 		}
 		
 		private static function countTestCases(test:Class):int
@@ -156,6 +159,7 @@ package org.sonatype.flexmojos.unitestingsupport.flexunit4
 		public function testRunFinished( result:Result ):void
 		{
 			running = false;
+			_socketReporter.numTestsRun = NB_TEST; // will send the test results
 		}
 		
     	/**
@@ -175,6 +179,7 @@ package org.sonatype.flexmojos.unitestingsupport.flexunit4
 		{
 			var descriptor:Descriptor = getDescriptorFromDescription(description);
 			_socketReporter.testFinished(descriptor.path + "." + descriptor.suite);
+			_socketReporter.numTestsRun--; // void the counter incrementation done in testFinished
 			trace("FlexUnit4: Test " + descriptor.method + " in " + descriptor.path + "." + descriptor.suite + " finished");
 		}
 		


### PR DESCRIPTION
http://www.mail-archive.com/flex-mojos@googlegroups.com/msg07212.html

Diagnostic:
FM is trying to count itself the number of test to be executed based on the Test annotations. When using dataprovider the real number of tests is often much than the one guessed by FM. Since FM is waiting to have the expected number of test executed to send the report, this lead to send an incomplete report to Maven although every tests are executed by FU4. The incomplete report in our case was hiding some test failures to the CI which is really dangerous...

Proposed hot fix:
Since the total number of test is no used elsewhere, I use a fixed value, don't increase the number of executed test until the end of the test where the fixed value is set in order to allow the report of the results.
Tested, and it works well here.

I think that a more deeper refactor would be necessary in order to rely on the hook offered by the various test framework to detect the test run completion instead of trying to count by ourself the number of test which is bug prone.
