### PR TITLE
Fix FlexUnit4 partial report when dataprovider are used

### DIFF
--- a/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-flexunit4/src/main/flex/net/flexmojos/oss/unitestingsupport/flexunit4/FlexUnit4Listener.as
+++ b/flexmojos-testing/flexmojos-unittest/flexmojos-unittest-flexunit4/src/main/flex/net/flexmojos/oss/unitestingsupport/flexunit4/FlexUnit4Listener.as
@@ -37,6 +37,7 @@ package net.flexmojos.oss.unitestingsupport.flexunit4
 
 	public class FlexUnit4Listener implements IRunListener, UnitTestRunner
 	{
+		private static const NB_TEST:int = 42;
 		private var running:Boolean = false;
 
 		private var _socketReporter:SocketReporter;
@@ -62,12 +63,14 @@ package net.flexmojos.oss.unitestingsupport.flexunit4
 			//This run statements executes the unit tests for the FlexUnit4 framework
  			var result:Result = flexUnitCore.run.apply( flexUnitCore, tests ); // The result seems to be always null
 
-			var count:int = 0;
-			for each (var test:Class in tests)
-			{
-				count += countTestCases(test);
-			}
-			return count;
+			//var count:int = 0;
+			//for each (var test:Class in tests)
+			//{
+			//	count += countTestCases(test);
+			//}
+			//return count;
+
+			return NB_TEST;
 		}
 		
 		private static function countTestCases(test:Class):int
@@ -160,6 +163,7 @@ package net.flexmojos.oss.unitestingsupport.flexunit4
 		public function testRunFinished( result:Result ):void
 		{
 			running = false;
+			_socketReporter.numTestsRun = NB_TEST; // will send the test results
 		}
 		
     	/**
@@ -179,7 +183,8 @@ package net.flexmojos.oss.unitestingsupport.flexunit4
 		{
 			var descriptor:Descriptor = getDescriptorFromDescription(description);
 			_socketReporter.testFinished(descriptor.path + "." + descriptor.suite, descriptor.method );
-			trace("FlexUnit4: Test " + descriptor.method + " in " + descriptor.path + "." + descriptor.suite + " finished");
+            _socketReporter.numTestsRun--; // void the counter incrementation done in testFinished
+            trace("FlexUnit4: Test " + descriptor.method + " in " + descriptor.path + "." + descriptor.suite + " finished");
 		}
 		
 		/**


### PR DESCRIPTION
Same as https://github.com/velo/flexmojos/pull/7 but for flexmojos-4.x branch
(CAUTION: I didn't tested on this branch since i'm not using this version of flexmojo, but seems to be same code)
